### PR TITLE
Updated code block for search results.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,14 @@ Your template file (`search.html` in the above example) should contain something
 lists the pages matching the search (substitute `paged_pages` for `pages` if using Pico-Pagination):
 
 ```twig
-{% for page in pages %}
-<div class="search_result">
-	<h2><a href="{{ page.url }}">{{ page.title }}</a></h2>
-	{% if page.description %}<p>{{ page.description }}</p>{% endif %}
-</div>
-{% endfor %}
+{% if pages %}
+    {% for page in pages %}
+        <div class="search_result">
+	    <h2><a href="{{ page.url }}">{{ page.title }}</a></h2>
+	    {% if page.description %}<p>{{ page.description }}</p>{% endif %}
+        </div>
+    {% endfor %}
+{% endif %}
 ```
 
 Now, you should be able to visit for example `yoursite.com/search/foobar` (adjust path accordingly if putting search.md


### PR DESCRIPTION
Only added {% if pages %}...{% endif %} for search results in code example. Otherwise, if no results found twig presents an error message that breaks down the results page.